### PR TITLE
chore(security): patch transitive dependency vulnerabilities via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49098,7 +49098,7 @@
         "@babel/plugin-transform-member-expression-literals": "^7.27.1",
         "@babel/plugin-transform-modules-amd": "^7.27.1",
         "@babel/plugin-transform-modules-commonjs": "^7.28.6",
-        "@babel/plugin-transform-modules-systemjs": "^7.29.0",
+        "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
         "@babel/plugin-transform-modules-umd": "^7.27.1",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
         "@babel/plugin-transform-new-target": "^7.27.1",
@@ -50260,7 +50260,7 @@
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "^3.0.1",
+            "fast-uri": ">=3.1.2",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }
@@ -58984,7 +58984,7 @@
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "^3.0.1",
+            "fast-uri": ">=3.1.2",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }
@@ -61963,7 +61963,7 @@
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "^3.0.1",
+            "fast-uri": ">=3.1.2",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,8 @@
     "braces": ">=3.0.3",
     "cross-spawn": ">=6.0.6",
     "lodash.template": "npm:lodash@^4.17.21",
-    "postcss": ">=8.5.10"
+    "postcss": ">=8.5.10",
+    "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
+    "fast-uri": ">=3.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- Add npm `overrides` for `@babel/plugin-transform-systemjs` >=7.29.4 and `fast-uri` >=3.1.2
- Addresses 3 open Dependabot alerts in ember-cli-heap