### PR TITLE
chore(security): patch shell-quote CVE-2026-9277

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44960,9 +44960,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -59291,7 +59291,7 @@
         "minimatch": "^3.0.4",
         "pidtree": "^0.3.0",
         "read-pkg": "^3.0.0",
-        "shell-quote": "^1.6.1",
+        "shell-quote": ">=1.8.4",
         "string.prototype.padend": "^3.0.0"
       },
       "dependencies": {
@@ -61185,9 +61185,9 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true
     },
     "shellwords": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "lodash.template": "npm:lodash@^4.17.21",
     "postcss": ">=8.5.10",
     "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
-    "fast-uri": ">=3.1.2"
+    "fast-uri": ">=3.1.2",
+    "shell-quote": ">=1.8.4"
   }
 }


### PR DESCRIPTION
## Summary
- Closes Dependabot alert #175 (shell-quote CRITICAL CVE-2026-9277)
- Adds `"shell-quote": ">=1.8.4"` to the existing `overrides` block in package.json
- Forces npm to resolve the vulnerable shell-quote <=1.8.3 (pulled in via npm-run-all) to the patched 1.8.4

## Changes
- shell-quote 1.8.3 -> 1.8.4 (via npm overrides)
- package-lock.json updated

## Test plan
- [ ] CI passes